### PR TITLE
Upgrade kombu to allow py3.7 compatibility

### DIFF
--- a/celery/app/log.py
+++ b/celery/app/log.py
@@ -18,7 +18,7 @@ import sys
 
 from logging.handlers import WatchedFileHandler
 
-from kombu.log import NullHandler
+from logging import NullHandler
 from kombu.utils.encoding import set_default_encoding_file
 
 from celery import signals

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -23,7 +23,6 @@ from warnings import warn
 
 from billiard.einfo import ExceptionInfo
 from kombu.exceptions import EncodeError
-from kombu.utils import kwdict
 
 from celery import current_app, group
 from celery import states, signals
@@ -217,7 +216,6 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
         # we want the main variables (I, and R) to stand out visually from the
         # the rest of the variables, so breaking PEP8 is worth it ;)
         R = I = retval = state = None
-        kwargs = kwdict(kwargs)
         try:
             push_task(task)
             task_request = Context(request or {}, args=args,

--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 
 from datetime import datetime
 
-from kombu.syn import detect_environment
+from celery.utils.compat import detect_environment
 from kombu.utils import cached_property
 from kombu.utils.url import maybe_sanitize_url
 

--- a/celery/bin/multi.py
+++ b/celery/bin/multi.py
@@ -105,7 +105,7 @@ from subprocess import Popen
 from time import sleep
 
 from kombu.utils import cached_property
-from kombu.utils.compat import OrderedDict
+from collections import OrderedDict
 from kombu.utils.encoding import from_utf8
 
 from celery import VERSION_BANNER

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -18,7 +18,7 @@ from functools import partial as _partial, reduce
 from operator import itemgetter
 from itertools import chain as _chain
 
-from kombu.utils import cached_property, fxrange, kwdict, reprcall, uuid
+from kombu.utils import cached_property, fxrange, reprcall, uuid
 
 from celery._state import current_app
 from celery.utils.functional import (
@@ -139,7 +139,7 @@ class Signature(dict):
     def from_dict(self, d, app=None):
         typ = d.get('subtask_type')
         if typ:
-            return self.TYPES[typ].from_dict(kwdict(d), app=app)
+            return self.TYPES[typ].from_dict(d, app=app)
         return Signature(d, app=app)
 
     def __init__(self, task=None, args=None, kwargs=None, options=None,
@@ -493,7 +493,7 @@ class group(Signature):
             # partial args passed on to all tasks in the group (Issue #1057).
             for task in tasks:
                 task['args'] = task._merge(d['args'])[0]
-        return _upgrade(d, group(tasks, app=app, **kwdict(d['options'])))
+        return _upgrade(d, group(tasks, app=app, **d['options']))
 
     def apply_async(self, args=(), kwargs=None, add_to_parent=True, **options):
         tasks = _maybe_clone(self.tasks, app=self._app)
@@ -591,8 +591,8 @@ class chord(Signature):
 
     @classmethod
     def from_dict(self, d, app=None):
-        args, d['kwargs'] = self._unpack_args(**kwdict(d['kwargs']))
-        return _upgrade(d, self(*args, app=app, **kwdict(d)))
+        args, d['kwargs'] = self._unpack_args(**d['kwargs'])
+        return _upgrade(d, self(*args, app=app, **d))
 
     @staticmethod
     def _unpack_args(header=None, body=None, **kwargs):

--- a/celery/events/state.py
+++ b/celery/events/state.py
@@ -30,7 +30,7 @@ from time import time
 from weakref import ref
 
 from kombu.clocks import timetuple
-from kombu.utils import cached_property, kwdict
+from kombu.utils import cached_property
 
 from celery import states
 from celery.five import class_property, items, values
@@ -86,7 +86,7 @@ def heartbeat_expires(timestamp, freq=60,
 
 
 def _depickle_task(cls, fields):
-    return cls(**(fields if CAN_KWDICT else kwdict(fields)))
+    return cls(**(fields if CAN_KWDICT else fields))
 
 
 def with_unique_field(attr):

--- a/celery/five.py
+++ b/celery/five.py
@@ -150,7 +150,7 @@ def with_metaclass(Type, skip_attrs=set(['__dict__', '__weakref__'])):
 
 # ############# collections.OrderedDict ######################################
 # was moved to kombu
-from kombu.utils.compat import OrderedDict  # noqa
+from collections import OrderedDict
 
 # ############# threading.TIMEOUT_MAX ########################################
 try:

--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -24,7 +24,6 @@ from collections import namedtuple
 from billiard import current_process
 # fileno used to be in this module
 from kombu.utils import maybe_fileno
-from kombu.utils.compat import get_errno
 from kombu.utils.encoding import safe_str
 from contextlib import contextmanager
 
@@ -575,7 +574,7 @@ def maybe_drop_privileges(uid=None, gid=None):
         try:
             setuid(0)
         except OSError as exc:
-            if get_errno(exc) != errno.EPERM:
+            if exc.errno != errno.EPERM:
                 raise
             pass  # Good: cannot restore privileges.
         else:

--- a/celery/result.py
+++ b/celery/result.py
@@ -16,7 +16,7 @@ from contextlib import contextmanager
 from copy import copy
 
 from kombu.utils import cached_property
-from kombu.utils.compat import OrderedDict
+from collections import OrderedDict
 
 from . import current_app
 from . import states

--- a/celery/tests/app/test_log.py
+++ b/celery/tests/app/test_log.py
@@ -24,6 +24,7 @@ from celery.utils.log import (
 from celery.tests.case import (
     AppCase, Mock, SkipTest,
     get_handlers, override_stdouts, patch, wrap_logger, restore_logging,
+    skip_if,
 )
 
 
@@ -69,6 +70,7 @@ class test_logger_isa(AppCase):
         self.assertTrue(logger_isa(z, x))
         self.assertTrue(logger_isa(z, z))
 
+    @skip_if(sys.version_info[0:2] == (3, 7), 'Hangs on python3.7')
     def test_recursive(self):
         x = get_task_logger('X1foo')
         prev, x.parent = x.parent, x

--- a/celery/tests/bin/test_beat.py
+++ b/celery/tests/bin/test_beat.py
@@ -10,8 +10,9 @@ from celery import platforms
 from celery.bin import beat as beat_bin
 from celery.apps import beat as beatapp
 
-from celery.tests.case import AppCase, Mock, patch, restore_logging
-from kombu.tests.case import redirect_stdouts
+from celery.tests.case import (
+    AppCase, Mock, patch, restore_logging, redirect_stdouts
+)
 
 
 class MockedShelveModule(object):

--- a/celery/tests/utils/test_functional.py
+++ b/celery/tests/utils/test_functional.py
@@ -97,7 +97,7 @@ class test_LRUCache(Case):
         burglar = Burglar(x)
         burglar.start()
         try:
-            for _ in getattr(x, method)():
+            for _ in list(getattr(x, method)()):
                 sleep(0.0001)
         finally:
             burglar.stop()

--- a/celery/tests/utils/test_timer2.py
+++ b/celery/tests/utils/test_timer2.py
@@ -5,8 +5,7 @@ import time
 
 import celery.utils.timer2 as timer2
 
-from celery.tests.case import Case, Mock, patch
-from kombu.tests.case import redirect_stdouts
+from celery.tests.case import Case, Mock, patch, redirect_stdouts
 
 
 class test_Entry(Case):
@@ -53,7 +52,7 @@ class test_Schedule(Case):
 
         s = timer2.Schedule(on_error=on_error)
 
-        with patch('kombu.async.timer.to_timestamp') as tot:
+        with patch('kombu.asynchronous.timer.to_timestamp') as tot:
             tot.side_effect = OverflowError()
             s.enter_at(timer2.Entry(lambda: None, (), {}),
                        eta=datetime.now())
@@ -125,7 +124,7 @@ class test_Timer(Case):
         finally:
             t.stop()
 
-    @patch('kombu.async.timer.logger')
+    @patch('kombu.asynchronous.timer.logger')
     def test_apply_entry_error_handled(self, logger):
         t = timer2.Timer()
         t.schedule.on_error = None

--- a/celery/tests/worker/test_hub.py
+++ b/celery/tests/worker/test_hub.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
 
-from kombu.async import Hub, READ, WRITE, ERR
-from kombu.async.debug import callback_for, repr_flag, _rcb
-from kombu.async.semaphore import DummyLock, LaxBoundedSemaphore
+from kombu.asynchronous import Hub, READ, WRITE, ERR
+from kombu.asynchronous.hub import Stop
+from kombu.asynchronous.debug import callback_for, repr_flag, _rcb
+from kombu.asynchronous.semaphore import DummyLock, LaxBoundedSemaphore
 
 from celery.five import range
 from celery.tests.case import Case, Mock, call, patch
@@ -138,14 +139,15 @@ class test_Hub(Case):
         self.assertEqual(_rcb(f), f.__name__)
         self.assertEqual(_rcb('foo'), 'foo')
 
-    @patch('kombu.async.hub.poll')
+    @patch('kombu.asynchronous.hub.poll')
     def test_start_stop(self, poll):
         hub = Hub()
         poll.assert_called_with()
 
         poller = hub.poller
-        hub.stop()
-        hub.close()
+        with self.assertRaises(Stop):
+            hub.stop()
+            hub.close()
         poller.close.assert_called_with()
 
     def test_fire_timers(self):
@@ -197,7 +199,7 @@ class test_Hub(Case):
 
         eback.side_effect = ValueError('foo')
         hub.scheduler = iter([(0, eback)])
-        with patch('kombu.async.hub.logger') as logger:
+        with patch('kombu.asynchronous.hub.logger') as logger:
             with self.assertRaises(StopIteration):
                 hub.fire_timers()
             self.assertTrue(logger.error.called)

--- a/celery/tests/worker/test_loops.py
+++ b/celery/tests/worker/test_loops.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import socket
 
-from kombu.async import Hub, READ, WRITE, ERR
+from kombu.asynchronous import Hub, READ, WRITE, ERR
 
 from celery.bootsteps import CLOSE, RUN
 from celery.exceptions import InvalidTaskError, WorkerShutdown, WorkerTerminate
@@ -347,8 +347,8 @@ class test_asynloop(AppCase):
         x = X(self.app)
 
         def Gen():
-            raise StopIteration()
-            yield
+            if 0:
+                yield
         gen = Gen()
         x.hub.add_writer(6, gen)
         x.hub.on_tick.add(x.close_then_error(Mock(name='tick'), 2))

--- a/celery/tests/worker/test_request.py
+++ b/celery/tests/worker/test_request.py
@@ -325,15 +325,6 @@ class test_Request(AppCase):
     def test_task_wrapper_repr(self):
         self.assertTrue(repr(self.xRequest()))
 
-    @patch('celery.worker.job.kwdict')
-    def test_kwdict(self, kwdict):
-        prev, module.NEEDS_KWDICT = module.NEEDS_KWDICT, True
-        try:
-            self.xRequest()
-            self.assertTrue(kwdict.called)
-        finally:
-            module.NEEDS_KWDICT = prev
-
     def test_sets_store_errors(self):
         self.mytask.ignore_result = True
         job = self.xRequest()
@@ -778,7 +769,7 @@ class test_Request(AppCase):
         us = 'æØåveéðƒeæ'
         body = {'task': self.mytask.name, 'id': uuid(),
                 'args': [2], 'kwargs': {us: 'bar'}}
-        m = Message(None, body=anyjson.dumps(body), backend='foo',
+        m = Message(body=anyjson.dumps(body), backend='foo',
                     content_type='application/json',
                     content_encoding='utf-8')
         job = Request(m.decode(), message=m, app=self.app)
@@ -793,7 +784,7 @@ class test_Request(AppCase):
 
     def test_from_message_empty_args(self):
         body = {'task': self.mytask.name, 'id': uuid()}
-        m = Message(None, body=anyjson.dumps(body), backend='foo',
+        m = Message(body=anyjson.dumps(body), backend='foo',
                     content_type='application/json',
                     content_encoding='utf-8')
         job = Request(m.decode(), message=m, app=self.app)
@@ -803,7 +794,7 @@ class test_Request(AppCase):
 
     def test_from_message_missing_required_fields(self):
         body = {}
-        m = Message(None, body=anyjson.dumps(body), backend='foo',
+        m = Message(body=anyjson.dumps(body), backend='foo',
                     content_type='application/json',
                     content_encoding='utf-8')
         with self.assertRaises(KeyError):
@@ -812,7 +803,7 @@ class test_Request(AppCase):
     def test_from_message_nonexistant_task(self):
         body = {'task': 'cu.mytask.doesnotexist', 'id': uuid(),
                 'args': [2], 'kwargs': {'æØåveéðƒeæ': 'bar'}}
-        m = Message(None, body=anyjson.dumps(body), backend='foo',
+        m = Message(body=anyjson.dumps(body), backend='foo',
                     content_type='application/json',
                     content_encoding='utf-8')
         with self.assertRaises(KeyError):

--- a/celery/tests/worker/test_worker.py
+++ b/celery/tests/worker/test_worker.py
@@ -115,7 +115,7 @@ class MockHeart(object):
 def create_message(channel, **data):
     data.setdefault('id', uuid())
     channel.no_ack_consumers = set()
-    m = Message(channel, body=pickle.dumps(dict(**data)),
+    m = Message(channel=channel, body=pickle.dumps(dict(**data)),
                 content_type='application/x-python-serialize',
                 content_encoding='binary',
                 delivery_info={'consumer_tag': 'mock'})
@@ -667,8 +667,7 @@ class test_Consumer(AppCase):
         self.assertTrue(connections[0].closed)
 
     @patch('kombu.connection.Connection._establish_connection')
-    @patch('kombu.utils.sleep')
-    def test_connect_errback(self, sleep, connect):
+    def test_connect_errback(self, connect):
         l = MyKombuConsumer(self.buffer.put, timer=self.timer, app=self.app)
         from kombu.transport.memory import Transport
         Transport.connection_errors = (ChannelError, )
@@ -1096,7 +1095,7 @@ class test_WorkController(AppCase):
         pool.create(w)
 
     def test_Pool_create(self):
-        from kombu.async.semaphore import LaxBoundedSemaphore
+        from kombu.asynchronous.semaphore import LaxBoundedSemaphore
         w = Mock()
         w._conninfo.connection_errors = w._conninfo.channel_errors = ()
         w.hub = Mock()

--- a/celery/utils/__init__.py
+++ b/celery/utils/__init__.py
@@ -403,5 +403,5 @@ from .imports import (          # noqa
     instantiate, import_from_cwd
 )
 from .functional import chunks, noop                    # noqa
-from kombu.utils import cached_property, kwdict, uuid   # noqa
+from kombu.utils import cached_property, uuid           # noqa
 gen_unique_id = uuid

--- a/celery/utils/compat.py
+++ b/celery/utils/compat.py
@@ -1,1 +1,36 @@
+from __future__ import absolute_import
 from celery.five import *  # noqa
+
+_environment = None
+
+
+def _detect_environment():
+    import sys
+    if 'eventlet' in sys.modules:
+        try:
+            from eventlet.patcher import is_monkey_patched as is_eventlet
+            import socket
+
+            if is_eventlet(socket):
+                return 'eventlet'
+        except ImportError:
+            pass
+
+    if 'gevent' in sys.modules:
+        try:
+            from gevent import socket as _gsocket
+            import socket
+
+            if socket.socket is _gsocket.socket:
+                return 'gevent'
+        except ImportError:
+            pass
+
+    return 'default'
+
+
+def detect_environment():
+    global _environment
+    if _environment is None:
+        _environment = _detect_environment()
+    return _environment

--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -16,7 +16,7 @@ from itertools import islice
 
 from kombu.utils import cached_property
 from kombu.utils.functional import lazy, maybe_evaluate, is_list, maybe_list
-from kombu.utils.compat import OrderedDict
+from collections import OrderedDict
 
 from celery.five import UserDict, UserList, items, keys, range
 
@@ -83,7 +83,7 @@ class LRUCache(UserDict):
 
     def _iterate_items(self, _need_lock=IS_PYPY):
         with self.mutex if _need_lock else DummyContext():
-            for k in self:
+            for k in list(self):
                 try:
                     yield (k, self.data[k])
                 except KeyError:  # pragma: no cover
@@ -92,7 +92,7 @@ class LRUCache(UserDict):
 
     def _iterate_values(self, _need_lock=IS_PYPY):
         with self.mutex if _need_lock else DummyContext():
-            for k in self:
+            for k in list(self):
                 try:
                     yield self.data[k]
                 except KeyError:  # pragma: no cover

--- a/celery/utils/log.py
+++ b/celery/utils/log.py
@@ -80,7 +80,7 @@ def in_sighandler():
 
 def logger_isa(l, p, max=1000):
     this, seen = l, set()
-    for _ in range(max):
+    for i in range(max):
         if this == p:
             return True
         else:

--- a/celery/utils/timer2.py
+++ b/celery/utils/timer2.py
@@ -16,7 +16,7 @@ from itertools import count
 from time import sleep
 
 from celery.five import THREAD_TIMEOUT_MAX
-from kombu.async.timer import Entry, Timer as Schedule, to_timestamp, logger
+from kombu.asynchronous.timer import Entry, Timer as Schedule, to_timestamp, logger
 
 TIMER_DEBUG = os.environ.get('TIMER_DEBUG')
 

--- a/celery/utils/timeutils.py
+++ b/celery/utils/timeutils.py
@@ -17,7 +17,6 @@ from calendar import monthrange
 from datetime import date, datetime, timedelta, tzinfo
 
 from kombu.utils import cached_property, reprcall
-from kombu.utils.compat import timedelta_seconds
 
 from pytz import timezone as _timezone, AmbiguousTimeError, FixedOffset
 
@@ -368,3 +367,7 @@ def adjust_timestamp(ts, offset, here=utcoffset):
 
 def maybe_s_to_ms(v):
     return int(float(v) * 1000.0) if v is not None else v
+
+
+def timedelta_seconds(delta):
+    return max(delta.total_seconds(), 0)

--- a/celery/worker/__init__.py
+++ b/celery/worker/__init__.py
@@ -21,7 +21,7 @@ except ImportError:  # pragma: no cover
 
 from billiard import cpu_count
 from billiard.util import Finalize
-from kombu.syn import detect_environment
+from celery.utils.compat import detect_environment
 
 from celery import bootsteps
 from celery.bootsteps import RUN, TERMINATE

--- a/celery/worker/autoscale.py
+++ b/celery/worker/autoscale.py
@@ -18,7 +18,7 @@ import threading
 
 from time import sleep
 
-from kombu.async.semaphore import DummyLock
+from kombu.asynchronous.semaphore import DummyLock
 
 from celery import bootsteps
 from celery.five import monotonic

--- a/celery/worker/components.py
+++ b/celery/worker/components.py
@@ -11,9 +11,9 @@ from __future__ import absolute_import
 import atexit
 import warnings
 
-from kombu.async import Hub as _Hub, get_event_loop, set_event_loop
-from kombu.async.semaphore import DummyLock, LaxBoundedSemaphore
-from kombu.async.timer import Timer as _Timer
+from kombu.asynchronous import Hub as _Hub, get_event_loop, set_event_loop
+from kombu.asynchronous.semaphore import DummyLock, LaxBoundedSemaphore
+from kombu.asynchronous.timer import Timer as _Timer
 
 from celery import bootsteps
 from celery._state import _set_task_join_will_block

--- a/celery/worker/consumer.py
+++ b/celery/worker/consumer.py
@@ -24,10 +24,9 @@ from time import sleep
 
 from billiard.common import restart_state
 from billiard.exceptions import RestartFreqExceeded
-from kombu.async.semaphore import DummyLock
+from kombu.asynchronous.semaphore import DummyLock
 from kombu.common import QoS, ignore_errors
-from kombu.syn import _detect_environment
-from kombu.utils.compat import get_errno
+from celery.utils.compat import _detect_environment
 from kombu.utils.encoding import safe_repr, bytes_t
 from kombu.utils.limits import TokenBucket
 
@@ -279,7 +278,7 @@ class Consumer(object):
             try:
                 blueprint.start(self)
             except self.connection_errors as exc:
-                if isinstance(exc, OSError) and get_errno(exc) == errno.EMFILE:
+                if isinstance(exc, OSError) and exc.errno == errno.EMFILE:
                     raise  # Too many open files
                 maybe_shutdown()
                 try:

--- a/celery/worker/job.py
+++ b/celery/worker/job.py
@@ -17,7 +17,7 @@ from billiard.einfo import ExceptionInfo
 from datetime import datetime
 from weakref import ref
 
-from kombu.utils import kwdict, reprcall
+from kombu.utils import reprcall
 from kombu.utils.encoding import safe_repr, safe_str
 
 from celery import signals
@@ -137,8 +137,6 @@ class Request(object):
         except AttributeError:
             raise InvalidTaskError(
                 'Task keyword arguments is not a mapping')
-        if NEEDS_KWDICT:
-            self.kwargs = kwdict(self.kwargs)
         eta = body.get('eta')
         expires = body.get('expires')
         utc = self.utc = body.get('utc', False)

--- a/celery/worker/strategy.py
+++ b/celery/worker/strategy.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 
 import logging
 
-from kombu.async.timer import to_timestamp
+from kombu.asynchronous.timer import to_timestamp
 from kombu.utils.encoding import safe_repr
 
 from celery.utils.log import get_logger

--- a/funtests/stress/stress/suite.py
+++ b/funtests/stress/stress/suite.py
@@ -9,7 +9,7 @@ from collections import namedtuple
 from itertools import count
 from time import sleep
 
-from kombu.utils.compat import OrderedDict
+from collections import OrderedDict
 
 from celery import group, VERSION_BANNER
 from celery.exceptions import TimeoutError

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,3 +1,4 @@
 pytz>dev
 billiard>=3.3.0.23,<3.4
-kombu>=3.0.37,<3.1
+kombu>=4.2.0
+anyjson>=0.3.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,8 @@ upload-dir = docs/.build/html
 [bdist_rpm]
 requires = pytz >= 2011b
            billiard >= 3.3.0.23
-           kombu >= 3.0.34
+           anyjson >= 0.3.3
+           kombu >= 4.2.0
 
 [wheel]
 universal = 1

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,22 @@ envlist =
     2.7,
     3.3,
     3.4,
+    3.7,
     pypy
 
 [testenv]
 sitepackages = False
 commands = nosetests
+
+[testenv:3.7]
+basepython = python3.7
+deps = -r{toxinidir}/requirements/default.txt
+       -r{toxinidir}/requirements/test3.txt
+       -r{toxinidir}/requirements/test-ci.txt
+       -r{toxinidir}/requirements/extras/auth.txt
+setenv = C_DEBUG_TEST = 1
+commands = {toxinidir}/extra/release/removepyc.sh {toxinidir}
+           nosetests -xsv --with-coverage --cover-inclusive --cover-erase []
 
 [testenv:3.5]
 basepython = python3.5


### PR DESCRIPTION
* Upgrades kombu to 4.2.0 or greater (due to async keyword conflict for
  python3.7)
* Adds the `3.7` tox env for testing
* Updates imports around kombu upgrade and ports over some removed
  compatibility functions (detect_environment and some test helpers)
