### PR TITLE
Change kombu dependency to direct ZIP link

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,3 +1,3 @@
 pytz>dev
 billiard>=3.3.0.23,<3.4
-kombu @ git+https://github.com/discord/kombu.git@discord-v3.0.37#egg=kombu
+https://github.com/discord/kombu/archive/discord-v3.0.37.zip

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,3 +1,3 @@
 pytz>dev
 billiard>=3.3.0.23,<3.4
-https://github.com/discord/kombu/archive/discord-v3.0.37.zip
+kombu @ https://github.com/discord/kombu/archive/discord-v3.0.37.zip

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ upload-dir = docs/.build/html
 [bdist_rpm]
 requires = pytz >= 2011b
            billiard >= 3.3.0.23
-           https://github.com/discord/kombu/archive/discord-v3.0.37.zip
+           kombu @ https://github.com/discord/kombu/archive/discord-v3.0.37.zip
 
 [wheel]
 universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ upload-dir = docs/.build/html
 [bdist_rpm]
 requires = pytz >= 2011b
            billiard >= 3.3.0.23
-           kombu @ git+https://github.com/discord/kombu.git@discord-v3.0.37#egg=kombu
+           https://github.com/discord/kombu/archive/discord-v3.0.37.zip
 
 [wheel]
 universal = 1


### PR DESCRIPTION
Change kombu dependency to direct HTTPS ZIP to enable dependency hashes.

This should solve the `pip-compile` warning:
```
# WARNING: pip install will require the following package to be hashed.
# Consider using a hashable URL like https://github.com/jazzband/pip-tools/archive/SOMECOMMIT.zip
kombu @ git+https://github.com/discord/kombu.git@discord-v3.0.37
```